### PR TITLE
fix(ci): change Python dependencies downloaded for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies
-        run: pip install 'ansible${{ matrix.ansible-version }}' molecule[docker] docker
+        run: pip install 'ansible${{ matrix.ansible-version }}' molecule molecule-plugins[docker] docker
 
       - name: Run Molecule tests
         run: |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Install Posit/RStudio Professional Drivers
 
+
 ## Table of content
 
 - [Default Variables](#default-variables)


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #

## Changes description

I changed which Python packages are installed for running tests (molecule[docker] -> molecule, molecule-plugins[docker]).

It seems that molecule doesn't include docker plugin in the molecule package (there was a release of a new 5.0.0 version). Also, the docker plugin was moved to [ansible-community/molecule-plugins](https://github.com/ansible-community/molecule-plugins), so it should be installed as molecule-plugins[docker]
