### PR TITLE
feat: add support for Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ name: CI
       - main
   schedule:
     - cron: '30 1 * * 3'
+  workflow_dispatch:
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
             platform: instance
           - distro: ubuntu2204
             platform: instance
+          - distro: ubuntu2404
+            platform: instance
           - distro: ubi9
             platform: instance-rh
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: shell-lint
 
   - repo: https://github.com/ansible-community/ansible-lint
-    rev: v6.0.2
+    rev: v25.4.0
     hooks:
       - id: ansible-lint
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@
 #
 # Release notes: <https://docs.posit.co/pro-drivers/documentation/>
 # @end
-rstudio_pro_drivers_version: "2023.12.1"
+rstudio_pro_drivers_version: "2025.03.0"
 
 # @var rstudio_pro_drivers_dependencies:description: >
 # System dependecies required for using Drivers on Debian/Ubuntu

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,8 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - focal
+        - jammy
+        - noble
     - name: EL
       versions:
         - "8"

--- a/vars/_jammy.yml
+++ b/vars/_jammy.yml
@@ -1,3 +1,0 @@
----
-
-rstudio_pro_drivers_download_url: "https://dl.posit.co/public/pro/deb/ubuntu/pool/focal/main/r/rs/rstudio-drivers_{{ rstudio_pro_drivers_version }}/rstudio-drivers_{{ rstudio_pro_drivers_version }}_{{ rstudio_pro_drivers_machine_map[ansible_machine] }}.deb"

--- a/vars/_ubuntu.yml
+++ b/vars/_ubuntu.yml
@@ -1,5 +1,2 @@
 ---
-
 rstudio_pro_drivers_download_url: "https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers_{{ rstudio_pro_drivers_version }}_{{ rstudio_pro_drivers_machine_map[ansible_machine] }}.deb"
-
-...


### PR DESCRIPTION
## Description
- Bumped the default version of the drivers to the latest one (which is required for Ubuntu 24.04
- Added support for Ubuntu 24.04
- Unified vars file for Ubuntu family

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
